### PR TITLE
feat: Remove possible incompatible characters for XML compatibility

### DIFF
--- a/hmdriver2/_xpath.py
+++ b/hmdriver2/_xpath.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import re
 from typing import Dict
 from lxml import etree
 from functools import cached_property
@@ -37,6 +38,8 @@ class _XPath:
     def _json2xml(hierarchy: Dict) -> etree.Element:
         attributes = hierarchy.get("attributes", {})
         tag = attributes.get("type", "orgRoot") or "orgRoot"
+        # Clean the "text" attribute to be compatible with XML format
+        attributes["text"] = re.sub(u"[^\u0020-\uD7FF\u0009\u000A\u000D\uE000-\uFFFD\U00010000-\U0010FFFF]+", "", attributes.get("text", ""))
         xml = etree.Element(tag, attrib=attributes)
 
         children = hierarchy.get("children", [])


### PR DESCRIPTION
最近我在HarmonyOS Next的手机华为应用市场里面用hmdriver2进行自动化获取所有应用信息，在爬取有些应用的时候由于页面中存在一些和XML不兼容的字符而报错。举个例子，在应用“中华万年历”详情页中，将介绍部分展开，用XPath的方式定位元素，会报以下错误：
Traceback (most recent call last):
  File "/Users/chenyige/Desktop/project/hmdriver2/main.py", line 6, in <module>
    d.xpath('//*[@id="__NavdestinationField__BackButton__Back__"]').click()
  File "/Users/chenyige/Desktop/project/hmdriver2/hmdriver2/_xpath.py", line 25, in __call__
    xml = _XPath._json2xml(hierarchy)
  File "/Users/chenyige/Desktop/project/hmdriver2/hmdriver2/_xpath.py", line 47, in _json2xml
    xml.append(_XPath._json2xml(item))
  File "/Users/chenyige/Desktop/project/hmdriver2/hmdriver2/_xpath.py", line 47, in _json2xml
    xml.append(_XPath._json2xml(item))
  File "/Users/chenyige/Desktop/project/hmdriver2/hmdriver2/_xpath.py", line 47, in _json2xml
    xml.append(_XPath._json2xml(item))
  [Previous line repeated 15 more times]
  File "/Users/chenyige/Desktop/project/hmdriver2/hmdriver2/_xpath.py", line 43, in _json2xml
    xml = etree.Element(tag, attrib=attributes)
  File "src/lxml/etree.pyx", line 3095, in lxml.etree.Element
  File "src/lxml/apihelpers.pxi", line 138, in lxml.etree._makeElement
  File "src/lxml/apihelpers.pxi", line 126, in lxml.etree._makeElement
  File "src/lxml/apihelpers.pxi", line 325, in lxml.etree._initNodeAttributes
  File "src/lxml/apihelpers.pxi", line 336, in lxml.etree._addAttributeToNode
  File "src/lxml/apihelpers.pxi", line 1530, in lxml.etree._utf8
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
错误原因是页面中存在一些和XML不兼容的字符，比如\b属于control character。为了解决这个问题，我用了 https://stackoverflow.com/questions/8733233/filtering-out-certain-bytes-in-python 上面的方法将这些非法字符移除（只考虑了text属性）。