### PR TITLE
xpath 增加获取info,text等属性方法

### DIFF
--- a/hmdriver2/_xpath.py
+++ b/hmdriver2/_xpath.py
@@ -29,7 +29,9 @@ class _XPath:
             raw_bounds: str = node.attrib.get("bounds")  # [832,1282][1125,1412]
             bounds: Bounds = parse_bounds(raw_bounds)
             logger.debug(f"{xpath} Bounds: {bounds}")
-            return _XMLElement(bounds, self._d)
+            _xe = _XMLElement(bounds, self._d)
+            setattr(_xe, "attrib_info", node.attrib)
+            return _xe
 
         return _XMLElement(None, self._d)
 
@@ -91,3 +93,17 @@ class _XMLElement:
     def input_text(self, text):
         self.click()
         self._d.input_text(text)
+
+    @property
+    @delay
+    def info(self) -> dict:
+        if hasattr(self, 'attrib_info'):
+            return getattr(self, 'attrib_info')
+        else:
+            logger.warning("the attribute <attrib_info> does not exists！")
+            return {}
+
+    @property
+    @delay
+    def text(self) -> str:
+        return self.info.get("text")


### PR DESCRIPTION
在实际使用中，我们会通过xpath 获取某个节点的文本进行比对，或其他操作。但原有的方法中没有这个操作，故增加了这个处理。
主要添加内容：
1、动态增加属性attrib_info,获取该节点下所有信息
2、_XMLElement 类中增加属性：info,text。info,对应获取attrib_info的信息；text,从attrib_info中的text属性中获取文本内容。