### PR TITLE
fix: some apps will have extra keys in get bounds method and crash

### DIFF
--- a/hmdriver2/_uiobject.py
+++ b/hmdriver2/_uiobject.py
@@ -182,11 +182,13 @@ class UiObject:
     @property
     def bounds(self) -> Bounds:
         _raw = self.__operate("Component.getBounds")
+        _raw = {k: v for k, v in _raw.items() if k in {"bottom", "left", "right", "top"}}
         return Bounds(**_raw)
 
     @property
     def boundsCenter(self) -> Point:
         _raw = self.__operate("Component.getBoundsCenter")
+        _raw = {k: v for k, v in _raw.items() if k in {"x", "y"}}
         return Point(**_raw)
 
     @property


### PR DESCRIPTION
<img width="778" alt="image" src="https://github.com/user-attachments/assets/e20c00b1-d249-4ebc-a5e9-fe08d4422199" />
如图，番茄小说有 displayId ，导致 crash